### PR TITLE
Fix attribute error

### DIFF
--- a/src/gui/pages/page_select_camera.py
+++ b/src/gui/pages/page_select_camera.py
@@ -54,7 +54,7 @@ class PageSelectCamera(SafeDisposableFrame):
         self.label.grid(row=1, column=0, padx=10, pady=(20, 10), sticky="nw")
 
         # Empty radio buttons
-        self.radio_var = tkinter.IntVar(0)
+        self.radio_var = tkinter.IntVar(value=0)
         self.prev_radio_value = None
         self.radios = []
 


### PR DESCRIPTION
This pull request solves the problem with the attribute error that occurs when you want to run the code.

```txt
Traceback (most recent call last):
  File "run_app.py", line 67, in <module>
  File "run_app.py", line 36, in __init__
  File "src\gui\main_gui.py", line 80, in __init__
  File "src\gui\pages\page_select_camera.py", line 57, in __init__
  File "tkinter\__init__.py", line 564, in __init__
  File "tkinter\__init__.py", line 372, in __init__
AttributeError: 'int' object has no attribute '_root'
```