### PR TITLE
fix for paths

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,35 +1,33 @@
-# Copyright 2023 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import copy
 import json
 import logging
 import shutil
 import time
 import tkinter as tk
+import os
 from pathlib import Path
 
 from src.singleton_meta import Singleton
 from src.task_killer import TaskKiller
 
-VERSION = "0.3.33"
+VERSION = "0.3.34"
 
-DEFAULT_JSON = Path("configs/default.json")
-BACKUP_PROFILE = Path("configs/default")
+DEFAULT_JSON = Path(f"C:/Users/{os.getlogin()}/Grimassist/configs/default.json")
+BACKUP_PROFILE = Path(f"C:/Users/{os.getlogin()}/Grimassist/configs/default")
 
 logger = logging.getLogger("ConfigManager")
 
+config_dir = f"C:/Users/{os.getlogin()}/Grimassist/configs/"
+default_dir = os.path.join(config_dir, "default")
+
+# Create the main config directory if it doesn't exist
+if not os.path.isdir(config_dir):
+    os.makedirs(config_dir, exist_ok=True)
+    shutil.copytree("configs", config_dir, dirs_exist_ok=True)
+
+# Create the default directory inside the config directory if it doesn't exist
+if not os.path.isdir(default_dir):
+    os.mkdir(default_dir)
 
 class ConfigManager(metaclass=Singleton):
 


### PR DESCRIPTION
There was a nasty bug on the installer

```
Traceback (most recent call last):
  File "grimassist.py", line 6, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "src\gui\__init__.py", line 2, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "src\gui\main_gui.py", line 8, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "src\gui\frames\__init__.py", line 2, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "src\gui\frames\frame_cam_preview.py", line 7, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "src\camera_manager.py", line 13, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 352, in exec_module
  File "src\config_manager.py", line 23, in <module>
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:/Users/admin-local/Grimassist/configs/'
```

Im hoping this fixes it